### PR TITLE
Avoid mixed content link traversal when using the query in the browser via https

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,9 @@ module.exports = {
     'ts-jest': {
       isolatedModules: true
     },
+    window: {
+      location: new URL("http://localhost")
+    }
   },
   setupFilesAfterEnv: [ './setup-jest.js' ],
   collectCoverage: true,

--- a/packages/actor-rdf-resolve-hypermedia-links-traverse/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-links-traverse/package.json
@@ -31,8 +31,9 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@comunica/core": "^2.0.1",
-    "@comunica/bus-rdf-resolve-hypermedia-links": "^2.0.1"
+    "@comunica/bus-rdf-resolve-hypermedia-links": "^2.0.1",
+    "@comunica/context-entries": "^2.2.0",
+    "@comunica/core": "^2.0.1"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-resolve-hypermedia-links-traverse/test/ActorRdfResolveHypermediaLinksTraverse-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-traverse/test/ActorRdfResolveHypermediaLinksTraverse-test.ts
@@ -67,5 +67,73 @@ describe('ActorRdfResolveHypermediaLinksTraverse', () => {
           { url: 'http://example.org' },
         ]});
     });
+
+    it('should run and convert insecure links to https in the browser', () => {
+      global.window = { location: new URL('https://mywebapp.com') };
+      actor = new ActorRdfResolveHypermediaLinksTraverse({ name: 'actor', bus });
+      const result = actor.run({ context: new ActionContext(),
+        metadata: { traverse: [
+          { url: 'http://example.org?abc' },
+          { url: 'http://example.org' },
+        ]}});
+      global.window = { location: new URL('http://localhost') };
+      return expect(result)
+        .resolves.toMatchObject({ links: [
+          { url: 'https://example.org?abc' },
+          { url: 'https://example.org' },
+        ]});
+    });
+
+    it('should run and keep insecure links when running from an insecure context', () => {
+      global.window = { location: new URL('http://mywebapp.com') };
+      actor = new ActorRdfResolveHypermediaLinksTraverse({ name: 'actor', bus });
+      const result = actor.run({ context: new ActionContext(),
+        metadata: { traverse: [
+          { url: 'http://example.org?abc' },
+          { url: 'http://example.org' },
+        ]}});
+      global.window = { location: new URL('http://localhost') };
+      return expect(result)
+        .resolves.toMatchObject({ links: [
+          { url: 'http://example.org?abc' },
+          { url: 'http://example.org' },
+        ]});
+    });
+
+    it('should run and not convert insecure links to https when upgradeInsecureRequests is set to false', () => {
+      global.window = { location: new URL('https://mywebapp.com') };
+      actor = new ActorRdfResolveHypermediaLinksTraverse({
+        name: 'actor', bus, upgradeInsecureRequests: false,
+      });
+      const result = actor.run({ context: new ActionContext(),
+        metadata: { traverse: [
+          { url: 'http://example.org?abc' },
+          { url: 'http://example.org' },
+        ]}});
+      global.window = { location: new URL('http://localhost') };
+      return expect(result)
+        .resolves.toMatchObject({ links: [
+          { url: 'http://example.org?abc' },
+          { url: 'http://example.org' },
+        ]});
+    });
+
+    it('should run and convert insecure links to https when upgradeInsecureRequests is set to true', () => {
+      global.window = { location: new URL('http://mywebapp.com') };
+      actor = new ActorRdfResolveHypermediaLinksTraverse({
+        name: 'actor', bus, upgradeInsecureRequests: true,
+      });
+      const result = actor.run({ context: new ActionContext(),
+        metadata: { traverse: [
+          { url: 'http://example.org?abc' },
+          { url: 'http://example.org' },
+        ]}});
+      global.window = { location: new URL('http://localhost') };
+      return expect(result)
+        .resolves.toMatchObject({ links: [
+          { url: 'https://example.org?abc' },
+          { url: 'https://example.org' },
+        ]});
+    });
   });
 });


### PR DESCRIPTION
**Problem**
When using the link traversal in the browser via insecure http - no issues exist. When using https you will get [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content) errors when the engine tries to fetch an http link.

Eventually this could lead to the query not functioning as expected with many links not being visited
Something that can easily be tested here: https://comunica.github.io/comunica-feature-link-traversal-web-clients/builds/default
![](https://i.imgur.com/7LAciyN.png)

**Proposed solution**
1. Check if we are using a browser (`globalThis.window` not being undefined)
*`globalThis` is used for compatibility with jest and NodeJS as well as the browser*
3. Check if the location URL is present (`globalThis.window.location` not being undefined)
4. Check if the location URL uses `https:`
*there is a window.isSecureContext but it [might not be supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/API/isSecureContext)*
6. If yes, check if the `fileLink.url` uses `http:`
7. If yes, replace it to `https:` to avoid mixed content errors

It could be that the remote server does not offer the `fileLink.url` in https - but it is a better attempt to try and visit it via https than to let the browser throw an error.
Example: http://qudt.org/vocab/unit/M  VS https://qudt.org/vocab/unit/M
The latter will not work - but on HTTPS, the first one won't work either.

**Current workarounds**
Current workarounds would be to use an HTTPS proxy that does not care about mixed content e.g. https://proxy.linkeddatafragments.org/

**Changes**
- Proposed solution (see above)
- Added jest config option for the window object
*Not absolutely required - but added for other future tests*
- Added unit test for replacing `http` links to `https` when the browser is using `https:`
- Added unit test for NOT replacing `http` links when the browser is not using `https:`

The following commit has been tested with NodeJS and in the browser where the issue is present.