### PR TITLE
Integration/tree web engine

### DIFF
--- a/engines/config-query-sparql-link-traversal/config/config-tree.json
+++ b/engines/config-query-sparql-link-traversal/config/config-tree.json
@@ -1,0 +1,11 @@
+{
+    "@context": [
+      "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^2.0.0/components/context.jsonld",
+      "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql-link-traversal/^0.0.0/components/context.jsonld"
+    ],
+    "import": [
+      "ccqslt:config/config-base.json",
+      "ccqslt:config/extract-links/actors/tree.json"
+    ]
+  }
+  

--- a/web-clients/overview.html
+++ b/web-clients/overview.html
@@ -74,6 +74,6 @@
     <div>
         <h3>TREE</h3>
         <a href="tree/" target="_parent">Web client</a><br /><br />
-        Configuration that follow all the relations of the current node of a TREE document.
+        Configuration that follow all the relations in a TREE document.
     </div>
 </body>

--- a/web-clients/overview.html
+++ b/web-clients/overview.html
@@ -74,6 +74,6 @@
     <div>
         <h3>Naive TREE link traversal</h3>
         <a href="tree/" target="_parent">Web client</a><br /><br />
-        Configuration that extracts that follow all the relation of the current node of a TREE document.
+        Configuration that follow all the relations of the current node of a TREE document.
     </div>
 </body>

--- a/web-clients/overview.html
+++ b/web-clients/overview.html
@@ -70,4 +70,10 @@
         <a href="follow-content-policies-conditional/" target="_parent">Web client</a><br /><br />
         Configuration that extracts <code>SCL</code> policies, follows links according to the <code>cMatch</code> reachability semantics, but only allows links to be followed if they also match at least one <code>SCL</code> policy.
     </div>
+
+    <div>
+        <h3>Naive TREE link traversal</h3>
+        <a href="tree/" target="_parent">Web client</a><br /><br />
+        Configuration that extracts that follow all the relation of the current node of a TREE document.
+    </div>
 </body>

--- a/web-clients/overview.html
+++ b/web-clients/overview.html
@@ -72,7 +72,7 @@
     </div>
 
     <div>
-        <h3>Naive TREE link traversal</h3>
+        <h3>TREE</h3>
         <a href="tree/" target="_parent">Web client</a><br /><br />
         Configuration that follow all the relations of the current node of a TREE document.
     </div>

--- a/web-clients/queries/traversal/cultural-heritage-thesaurus.sparql
+++ b/web-clients/queries/traversal/cultural-heritage-thesaurus.sparql
@@ -1,0 +1,5 @@
+# 8. Cultural Heritage Thesaurus
+# Datasources: https://treecg.github.io/demo_data/cht.ttl
+SELECT * WHERE {
+    ?s <http://www.w3.org/2004/02/skos/core#broader> ?o.
+}

--- a/web-clients/queries/traversal/flanders-streets-registery.sparql
+++ b/web-clients/queries/traversal/flanders-streets-registery.sparql
@@ -1,0 +1,6 @@
+# 7. Flanders street registry
+# Datasources: https://tree.linkeddatafragments.org/data/addressregister/streetnames/
+SELECT * WHERE {
+    ?s <http://www.w3.org/2000/01/rdf-schema#label> ?o.
+    FILTER(LANG(?o) = "nl")
+}

--- a/web-clients/queries/traversal/sncb-ldes.sparql
+++ b/web-clients/queries/traversal/sncb-ldes.sparql
@@ -1,0 +1,5 @@
+# 9. SNCB connections LDES
+# Datasources: https://graph.irail.be/sncb/connections/feed
+SELECT * WHERE {
+    ?s <http://semweb.mmlab.be/ns/linkedconnections#departureStop> ?o.
+}


### PR DESCRIPTION
Configuration to generate a query engine page on the comunica web traversal [webpage](https://comunica.dev/research/link_traversal/). Three TREE query example has also been added. Follow up of PR #77