### PR TITLE
Use --cwd with Yarn as a replacement for --prefix from npm

### DIFF
--- a/web-clients/build-web-clients.sh
+++ b/web-clients/build-web-clients.sh
@@ -27,7 +27,7 @@ for config in ../config-query-sparql-link-traversal/config/*.json; do
 
   # Build web client
   echo -e "\033[1m\033[34mBuilding config $id\033[0m"
-  yarn run --prefix $cwd/web-clients generate -- $cwdengine/$config \
+  yarn --cwd $cwd/web-clients run generate $cwdengine/$config \
     -d $cwd/web-clients/builds/$id \
     -s $cwd/web-clients/settings.custom.json \
     -q $cwd/web-clients/queries \


### PR DESCRIPTION
This should fix the issue with the web client build script failing. It seems npm uses `--prefix` but yarn has a `--cwd` option instead.