### PR TITLE
Fix link metadata disappearing when priority=0 in pushed links

### DIFF
--- a/packages/actor-rdf-resolve-hypermedia-links-queue-priority/lib/LinkQueuePriority.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-priority/lib/LinkQueuePriority.ts
@@ -22,11 +22,13 @@ export class LinkQueuePriority implements ILinkQueue {
 
     // If we push a link that has no metadata or has metadata but no priority
     // we set priority to 0 and always set index to end of array (and upheap from there)
-    if (!link.metadata || !link.metadata.priority) {
-      link.metadata = { priority: 0, index: idx };
-    } else {
+    if (link.metadata) {
+      link.metadata.priority ??= 0;
       link.metadata.index = idx;
+    } else {
+      link.metadata = { priority: 0, index: idx };
     }
+
     this.links.push(link);
 
     // Add to Records to allow fast updates in priority

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-priority/test/LinkQueuePriority-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-priority/test/LinkQueuePriority-test.ts
@@ -57,7 +57,7 @@ describe('LinkQueuePriority', () => {
         { url: 'a', metadata: { priority: 0, index: 0, key: 'value' }},
       ]);
     });
-    it('retains metadta when zero priority is given', () => {
+    it('retains metadata when zero priority is given', () => {
       queue.push({ url: 'a', metadata: { key: 'value', priority: 0 }});
       expect(queue.links).toEqual([
         { url: 'a', metadata: { priority: 0, index: 0, key: 'value' }},

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-priority/test/LinkQueuePriority-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-priority/test/LinkQueuePriority-test.ts
@@ -51,6 +51,18 @@ describe('LinkQueuePriority', () => {
         { url: 'b', metadata: { priority: 0, index: 1 }},
       ]);
     });
+    it('retains metadata when no priority is given', () => {
+      queue.push({ url: 'a', metadata: { key: 'value' }});
+      expect(queue.links).toEqual([
+        { url: 'a', metadata: { priority: 0, index: 0, key: 'value' }},
+      ]);
+    });
+    it('retains metadta when zero priority is given', () => {
+      queue.push({ url: 'a', metadata: { key: 'value', priority: 0 }});
+      expect(queue.links).toEqual([
+        { url: 'a', metadata: { priority: 0, index: 0, key: 'value' }},
+      ]);
+    });
     it('instantiates metadata object if no metadata is given', () => {
       queue.push({ url: 'a' });
       queue.push({ url: 'b' });


### PR DESCRIPTION
In the priority queue, link metadata was lost when link.metadata.priority = 0 due to a falsy check in the previous implementation. This has been fixed, with test cases added to cover the bug.






