### PR TITLE
Add link filter type and filtering link queue wrapper

### DIFF
--- a/engines/config-query-sparql-link-traversal/config/rdf-resolve-hypermedia-links-queue/actors/wrapper-filter.json
+++ b/engines/config-query-sparql-link-traversal/config/rdf-resolve-hypermedia-links-queue/actors/wrapper-filter.json
@@ -1,0 +1,16 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^4.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/^0.0.0/components/context.jsonld"
+  ],
+  "@id": "urn:comunica:default:Runner",
+  "@type": "Runner",
+  "actors": [
+    {
+      "@id": "urn:comunica:default:rdf-resolve-hypermedia-links-queue/actors#wrapper-filter",
+      "@type": "ActorRdfResolveHypermediaLinksQueueWrapperFilter",
+      "beforeActors": { "@id": "urn:comunica:default:rdf-resolve-hypermedia-links-queue/actors#fifo" },
+      "mediatorRdfResolveHypermediaLinksQueue": { "@id": "urn:comunica:default:rdf-resolve-hypermedia-links-queue/mediators#main" }
+    }
+  ]
+}

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/README.md
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/README.md
@@ -1,0 +1,37 @@
+# Comunica Hypermedia Links Queue Wrapper for Link Filtering
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-rdf-resolve-hypermedia-links-queue-wrapper-filter.svg)](https://www.npmjs.com/package/@comunica/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter)
+
+An [RDF Resolve Hypermedia Links Queue](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-resolve-hypermedia-links-queue) actor
+that wraps over another link queue provided by the bus,
+and filters the links that can be taken out of the queue.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica),
+and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
+
+[Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter
+```
+
+## Configure
+
+After installing, this package can be added to your engine's configuration as follows:
+```json
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/^0.0.0/components/context.jsonld"
+  ],
+  "actors": [
+    {
+      "@id": "urn:comunica:default:rdf-resolve-hypermedia-links-queue/actors#wrapper-filter",
+      "@type": "ActorRdfResolveHypermediaLinksQueueWrapperFilter",
+      "beforeActors": { "@id": "urn:comunica:default:rdf-resolve-hypermedia-links-queue/actors#fifo" },
+      "mediatorRdfResolveHypermediaLinksQueue": { "@id": "urn:comunica:default:rdf-resolve-hypermedia-links-queue/mediators#main" }
+    }
+  ]
+}
+```

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/ActorRdfResolveHypermediaLinksQueueWrapperFilter.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/ActorRdfResolveHypermediaLinksQueueWrapperFilter.ts
@@ -1,0 +1,51 @@
+import { ActorRdfResolveHypermediaLinksQueue } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
+import type {
+  IActionRdfResolveHypermediaLinksQueue,
+  IActorRdfResolveHypermediaLinksQueueOutput,
+  IActorRdfResolveHypermediaLinksQueueArgs,
+  MediatorRdfResolveHypermediaLinksQueue,
+} from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
+import { KeysRdfResolveHypermediaLinks } from '@comunica/context-entries-link-traversal';
+import type { IActorTest, TestResult } from '@comunica/core';
+import { ActionContextKey, failTest, passTestVoid } from '@comunica/core';
+import { LinkQueueWrapperFilter } from './LinkQueueWrapperFilter';
+
+/**
+ * Comunica hypermedia link queue actor that wraps link queues under a filter.
+ */
+export class ActorRdfResolveHypermediaLinksQueueWrapperFilter extends ActorRdfResolveHypermediaLinksQueue {
+  private readonly mediatorRdfResolveHypermediaLinksQueue: MediatorRdfResolveHypermediaLinksQueue;
+
+  private static readonly keyWrapped = new ActionContextKey<boolean>(
+    '@comunica/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter:wrapped',
+  );
+
+  public constructor(args: IActorRdfResolveHypermediaLinksQueueWrapperFilterArgs) {
+    super(args);
+    this.mediatorRdfResolveHypermediaLinksQueue = args.mediatorRdfResolveHypermediaLinksQueue;
+  }
+
+  public async test(action: IActionRdfResolveHypermediaLinksQueue): Promise<TestResult<IActorTest>> {
+    if (action.context.get(ActorRdfResolveHypermediaLinksQueueWrapperFilter.keyWrapped)) {
+      return failTest('Unable to wrap link queues multiple times');
+    }
+    if (!action.context.has(KeysRdfResolveHypermediaLinks.linkFilters)) {
+      return failTest('Unable to wrap link queue with missing filter list');
+    }
+    return passTestVoid();
+  }
+
+  public async run(action: IActionRdfResolveHypermediaLinksQueue): Promise<IActorRdfResolveHypermediaLinksQueueOutput> {
+    const context = action.context.set(ActorRdfResolveHypermediaLinksQueueWrapperFilter.keyWrapped, true);
+    const linkFilters = action.context.getSafe(KeysRdfResolveHypermediaLinks.linkFilters);
+    const { linkQueue } = await this.mediatorRdfResolveHypermediaLinksQueue.mediate({ ...action, context });
+    return {
+      linkQueue: new LinkQueueWrapperFilter(linkQueue, linkFilters),
+    };
+  }
+}
+
+export interface IActorRdfResolveHypermediaLinksQueueWrapperFilterArgs extends
+  IActorRdfResolveHypermediaLinksQueueArgs {
+  mediatorRdfResolveHypermediaLinksQueue: MediatorRdfResolveHypermediaLinksQueue;
+}

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/LinkQueueWrapperFilter.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/LinkQueueWrapperFilter.ts
@@ -1,0 +1,27 @@
+import type { ILinkQueue, ILink } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
+import { LinkQueueWrapper } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
+import type { LinkFilterType } from '@comunica/types-link-traversal';
+
+/**
+ * A link queue wrapper that filters away links.
+ */
+export class LinkQueueWrapperFilter extends LinkQueueWrapper {
+  private readonly filters: LinkFilterType[];
+
+  public constructor(linkQueue: ILinkQueue, linkFilters: LinkFilterType[]) {
+    super(linkQueue);
+    this.filters = linkFilters;
+  }
+
+  public override pop(): ILink | undefined {
+    let link = super.pop();
+    while (link) {
+      if (this.filters.some(filter => !filter(link!))) {
+        link = super.pop();
+      } else {
+        break;
+      }
+    }
+    return link;
+  }
+}

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/LinkQueueWrapperFilter.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/LinkQueueWrapperFilter.ts
@@ -1,14 +1,14 @@
 import type { ILinkQueue, ILink } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
 import { LinkQueueWrapper } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
-import type { LinkFilterType } from '@comunica/types-link-traversal';
+import type { LinkFilter } from '@comunica/types-link-traversal';
 
 /**
  * A link queue wrapper that filters away links.
  */
 export class LinkQueueWrapperFilter extends LinkQueueWrapper {
-  private readonly filters: LinkFilterType[];
+  private readonly filters: LinkFilter[];
 
-  public constructor(linkQueue: ILinkQueue, linkFilters: LinkFilterType[]) {
+  public constructor(linkQueue: ILinkQueue, linkFilters: LinkFilter[]) {
     super(linkQueue);
     this.filters = linkFilters;
   }

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/index.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './ActorRdfResolveHypermediaLinksQueueWrapperFilter';

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@comunica/types-link-traversal",
+  "name": "@comunica/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter",
   "version": "0.6.0",
-  "description": "Typings module for Comunica Link Traversal",
+  "description": "Comunica hypermedia links queue wrapper for filtering links",
   "lsd:module": true,
   "license": "MIT",
   "funding": {
@@ -12,25 +12,23 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/comunica/comunica-feature-link-traversal.git",
-    "directory": "packages/types-link-traversal"
+    "directory": "packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter"
   },
   "bugs": {
     "url": "https://github.com/comunica/comunica-feature-link-traversal/issues"
   },
   "keywords": [
     "comunica",
-    "types"
+    "actor",
+    "rdf-resolve-hypermedia-links-queue",
+    "wrapper-filter"
   ],
-  "sideEffects": false,
   "main": "lib/index.js",
   "typings": "lib/index",
   "publishConfig": {
     "access": "public"
   },
   "files": [
-    "bin/**/*.d.ts",
-    "bin/**/*.js",
-    "bin/**/*.js.map",
     "components",
     "lib/**/*.d.ts",
     "lib/**/*.js",
@@ -38,10 +36,13 @@
   ],
   "scripts": {
     "build": "yarn run build:ts && yarn run build:components",
-    "build:ts": "node \"../../node_modules/types-link-traversalcript/bin/tsc\"",
+    "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
     "build:components": "componentsjs-generator"
   },
   "dependencies": {
-    "@comunica/types": "^4.1.0"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^4.1.0",
+    "@comunica/context-entries-link-traversal": "^0.6.0",
+    "@comunica/core": "^4.1.0",
+    "@comunica/types-link-traversal": "^0.6.0"
   }
 }

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/test/ActorRdfResolveHypermediaLinksQueueWrapperFilter-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/test/ActorRdfResolveHypermediaLinksQueueWrapperFilter-test.ts
@@ -1,0 +1,61 @@
+import type { MediatorRdfResolveHypermediaLinksQueue } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
+import { KeysRdfResolveHypermediaLinks } from '@comunica/context-entries-link-traversal';
+import { ActionContext, Bus } from '@comunica/core';
+import {
+  ActorRdfResolveHypermediaLinksQueueWrapperFilter,
+} from '../lib/ActorRdfResolveHypermediaLinksQueueWrapperFilter';
+import { LinkQueueWrapperFilter } from '../lib/LinkQueueWrapperFilter';
+import '@comunica/utils-jest';
+
+describe('ActorRdfResolveHypermediaLinksQueueWrapperFilter', () => {
+  let bus: any;
+  let mediatorRdfResolveHypermediaLinksQueue: MediatorRdfResolveHypermediaLinksQueue;
+  let actor: ActorRdfResolveHypermediaLinksQueueWrapperFilter;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+    mediatorRdfResolveHypermediaLinksQueue = <any> {
+      mediate: jest.fn(() => ({ linkQueue: 'inner' })),
+    };
+    actor = new ActorRdfResolveHypermediaLinksQueueWrapperFilter({
+      bus,
+      name: 'actor',
+      mediatorRdfResolveHypermediaLinksQueue,
+    });
+  });
+
+  describe('test', () => {
+    it('should accept', async() => {
+      await expect(actor.test({
+        firstUrl: 'first',
+        context: new ActionContext({ [KeysRdfResolveHypermediaLinks.linkFilters.name]: []}),
+      })).resolves.toPassTestVoid();
+    });
+
+    it('should reject with a missing filter list', async() => {
+      await expect(actor.test({
+        firstUrl: 'first',
+        context: new ActionContext(),
+      })).resolves.toFailTest('Unable to wrap link queue with missing filter list');
+    });
+
+    it('should reject when wrapped already', async() => {
+      await expect(actor.test({
+        firstUrl: 'first',
+        context: new ActionContext({
+          [(<any>ActorRdfResolveHypermediaLinksQueueWrapperFilter).keyWrapped.name]: true,
+          [KeysRdfResolveHypermediaLinks.linkFilters.name]: [],
+        }),
+      })).resolves.toFailTest('Unable to wrap link queues multiple times');
+    });
+  });
+
+  describe('run', () => {
+    it('should execute successfully', async() => {
+      await expect(actor.run({
+        firstUrl: 'first',
+        context: new ActionContext({ [KeysRdfResolveHypermediaLinks.linkFilters.name]: []}),
+      })).resolves.toEqual({ linkQueue: expect.any(LinkQueueWrapperFilter) });
+    });
+  });
+});

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/test/LinkQueueWrapperFilter-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-wrapper-filter/test/LinkQueueWrapperFilter-test.ts
@@ -1,0 +1,33 @@
+import type { ILink, ILinkQueue } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
+import { LinkQueueWrapperFilter } from '../lib/LinkQueueWrapperFilter';
+
+describe('LinkQueueWrapperFilter', () => {
+  let queue: ILinkQueue;
+  let links: ILink[];
+  let wrapper: LinkQueueWrapperFilter;
+
+  beforeEach(() => {
+    links = [];
+    queue = <any> {
+      pop: jest.fn(() => links.shift()),
+    };
+    wrapper = new LinkQueueWrapperFilter(queue, [ link => link.url.startsWith('https://') ]);
+  });
+
+  describe('pop', () => {
+    it('retrieves from the wrapped queue', () => {
+      expect(queue.pop).not.toHaveBeenCalled();
+      expect(wrapper.pop()).toBeUndefined();
+      expect(queue.pop).toHaveBeenCalledTimes(1);
+    });
+
+    it('filters out links that are rejected by the filter functions', () => {
+      const httpUri = { url: 'http://localhost' };
+      const httpsUri = { url: 'https://localhost' };
+      links.push(httpUri, httpsUri);
+      expect(queue.pop).not.toHaveBeenCalled();
+      expect(wrapper.pop()).toBe(httpsUri);
+      expect(queue.pop).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/context-entries-link-traversal/lib/Keys.ts
+++ b/packages/context-entries-link-traversal/lib/Keys.ts
@@ -1,5 +1,5 @@
 import { ActionContextKey } from '@comunica/core';
-import type { AnnotateSourcesType, LinkFilterType } from '@comunica/types-link-traversal';
+import type { AnnotateSourcesType, LinkFilter } from '@comunica/types-link-traversal';
 
 /**
  * When adding entries to this file, also add a shortcut for them in the contextKeyShortcuts TSDoc comment in
@@ -18,7 +18,7 @@ export const KeysRdfResolveHypermediaLinks = {
    * Context entry containing the link filters applied on link queues within the context scope.
    * Setting this entry too high in the context hierarchy could result in too much being filtered out.
    */
-  linkFilters: new ActionContextKey<LinkFilterType[]>(
+  linkFilters: new ActionContextKey<LinkFilter[]>(
     '@comunica/bus-rdf-resolve-hypermedia-links:linkFilters',
   ),
 };

--- a/packages/context-entries-link-traversal/lib/Keys.ts
+++ b/packages/context-entries-link-traversal/lib/Keys.ts
@@ -1,5 +1,5 @@
 import { ActionContextKey } from '@comunica/core';
-import type { AnnotateSourcesType } from '@comunica/types-link-traversal';
+import type { AnnotateSourcesType, LinkFilterType } from '@comunica/types-link-traversal';
 
 /**
  * When adding entries to this file, also add a shortcut for them in the contextKeyShortcuts TSDoc comment in
@@ -8,12 +8,18 @@ import type { AnnotateSourcesType } from '@comunica/types-link-traversal';
  */
 
 export const KeysRdfResolveHypermediaLinks = {
-
   /**
    * Context entry for indicating the type of source annotation.
    */
   annotateSources: new ActionContextKey<AnnotateSourcesType>(
     '@comunica/bus-rdf-resolve-hypermedia-links:annotateSources',
+  ),
+  /**
+   * Context entry containing the link filters applied on link queues within the context scope.
+   * Setting this entry too high in the context hierarchy could result in too much being filtered out.
+   */
+  linkFilters: new ActionContextKey<LinkFilterType[]>(
+    '@comunica/bus-rdf-resolve-hypermedia-links:linkFilters',
   ),
 };
 

--- a/packages/types-link-traversal/lib/LinkFilter.ts
+++ b/packages/types-link-traversal/lib/LinkFilter.ts
@@ -5,4 +5,4 @@ import type { ILink } from '@comunica/types';
  * @param {ILink} link The link to be tested.
  * @returns {boolean} True if the link should be considered, false if it should be discarded.
  */
-export type LinkFilterType = (link: ILink) => boolean;
+export type LinkFilter = (link: ILink) => boolean;

--- a/packages/types-link-traversal/lib/LinkFilterType.ts
+++ b/packages/types-link-traversal/lib/LinkFilterType.ts
@@ -1,0 +1,8 @@
+import type { ILink } from '@comunica/types';
+
+/**
+ * Test a given link to determine whether it should be accepted or not.
+ * @param {ILink} link The link to be tested.
+ * @returns {boolean} True if the link should be considered, false if it should be discarded.
+ */
+export type LinkFilterType = (link: ILink) => boolean;

--- a/packages/types-link-traversal/lib/index.ts
+++ b/packages/types-link-traversal/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './AnnotateSourcesType';
+export * from './LinkFilterType';

--- a/packages/types-link-traversal/lib/index.ts
+++ b/packages/types-link-traversal/lib/index.ts
@@ -1,2 +1,2 @@
 export * from './AnnotateSourcesType';
-export * from './LinkFilterType';
+export * from './LinkFilter';


### PR DESCRIPTION
This is an implementation of link filters and a queue that performs filtering based on such filters. The filter list is only checked when popping links, to minimise the overhead and avoid scaling issues.

Any feedback would be welcome. :slightly_smiling_face: 