### PR TITLE
Allow the statistic-link-discovery to register seed documents

### DIFF
--- a/engines/query-sparql-link-traversal-solid/package.json
+++ b/engines/query-sparql-link-traversal-solid/package.json
@@ -295,7 +295,6 @@
     "@comunica/bus-function-factory": "^4.0.2",
     "@comunica/bus-http-invalidate": "^4.0.2",
     "@comunica/bus-query-operation": "^4.0.2",
-    "@comunica/config-query-sparql": "~4.0.1",
     "@comunica/config-query-sparql-link-traversal": "^0.6.1",
     "@comunica/context-entries": "^4.0.2",
     "@comunica/context-entries-link-traversal": "^0.6.0",

--- a/engines/query-sparql-link-traversal/package.json
+++ b/engines/query-sparql-link-traversal/package.json
@@ -293,7 +293,6 @@
     "@comunica/bus-function-factory": "^4.0.2",
     "@comunica/bus-http-invalidate": "^4.0.2",
     "@comunica/bus-query-operation": "^4.0.2",
-    "@comunica/config-query-sparql": "4.0.1",
     "@comunica/config-query-sparql-link-traversal": "^0.6.1",
     "@comunica/core": "^4.0.2",
     "@comunica/logger-void": "^4.0.2",

--- a/packages/actor-optimize-query-operation-set-seed-sources-quadpattern-iris/lib/ActorOptimizeQueryOperationSetSeedSourcesQuadpatternIris.ts
+++ b/packages/actor-optimize-query-operation-set-seed-sources-quadpattern-iris/lib/ActorOptimizeQueryOperationSetSeedSourcesQuadpatternIris.ts
@@ -43,9 +43,11 @@ export class ActorOptimizeQueryOperationSetSeedSourcesQuadpatternIris extends Ac
             const traversalTracker: IStatisticBase<IDiscoverEventData> | undefined =
               action.context.get(KeysStatistics.discoveredLinks);
             if (traversalTracker) {
-              traversalTracker.updateStatistic({ url: source, metadata: { seed: true }}, { url: 'root' });
+              traversalTracker.updateStatistic(
+                { url: source, metadata: { seed: true }},
+                { url: 'root', metadata: {}},
+              );
             }
-
             return (await this.mediatorQuerySourceIdentify.mediate({
               querySourceUnidentified: {
                 value: source,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6998,15 +6998,15 @@
   dependencies:
     "@comunica/config-query-sparql" "~4.0.1"
 
-"@comunica/config-query-sparql@4.0.1", "@comunica/config-query-sparql@^4.0.1", "@comunica/config-query-sparql@~4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-4.0.1.tgz#ad7da2b3636aaf7dd3eb5b4918c76ac3bf2c61d7"
-  integrity sha512-jNuRl7PmOKillPfvIzmO+I7IFP0nroFQrZaX/4pUIqe4WNrSCzjZqrLnru0BQtFE5LXcaEA9IdtISSfjwTFt2w==
-
 "@comunica/config-query-sparql@^2.0.1":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz#1030ee76d5532bc6a09a6c8af26a06c7311a5861"
   integrity sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA==
+
+"@comunica/config-query-sparql@^4.0.1", "@comunica/config-query-sparql@~4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-4.0.1.tgz#ad7da2b3636aaf7dd3eb5b4918c76ac3bf2c61d7"
+  integrity sha512-jNuRl7PmOKillPfvIzmO+I7IFP0nroFQrZaX/4pUIqe4WNrSCzjZqrLnru0BQtFE5LXcaEA9IdtISSfjwTFt2w==
 
 "@comunica/context-entries@^2.10.0":
   version "2.10.0"
@@ -7559,6 +7559,23 @@
     "@comunica/core" "^4.0.1"
     componentsjs "^6.2.0"
     process "^0.11.10"
+
+"@comunica/statistic-base@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@comunica/statistic-base/-/statistic-base-4.0.2.tgz#dc5f13ab88238d6fa1fd8397a512bdfc05d6d619"
+  integrity sha512-8tOfYXYAsXgq37rHjWCN7QZy9lqcoNxhd2MZeta8lguyZP3xdreWYvDLeTvr+U770JtXsD0b2yNBF98BfjWkJw==
+  dependencies:
+    "@comunica/types" "^4.0.2"
+
+"@comunica/statistic-link-discovery@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@comunica/statistic-link-discovery/-/statistic-link-discovery-4.0.2.tgz#eff21005d219d18f66f01c6caf6b6bcad73047f3"
+  integrity sha512-OWdWwZ0emdyWVVUrQNroPMvDpTbKiSNGaVqJ70zsbD1utztls7uVU1GbgS+LGA5N4ISPHGk0LtdEq1KnvRcn0w==
+  dependencies:
+    "@comunica/context-entries" "^4.0.2"
+    "@comunica/core" "^4.0.2"
+    "@comunica/statistic-base" "^4.0.2"
+    "@comunica/types" "^4.0.2"
 
 "@comunica/types@4.0.2", "@comunica/types@^4.0.2":
   version "4.0.2"
@@ -18933,7 +18950,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18950,15 +18967,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -19029,7 +19037,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19042,13 +19050,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -20115,7 +20116,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20128,15 +20129,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Seed documents from the query were not registered in the StatisticLinkDiscovery class. This change fixes this and includes a test case for the added code.
In addition it fixes a problem identified by the `yarn run depcheck` command that states the `@comunica/config-query-sparql` dependencies are not needed.