### PR TITLE
Remove hash join

### DIFF
--- a/engines/config-query-sparql-link-traversal/config/rdf-join/actors-inner-adaptive.json
+++ b/engines/config-query-sparql-link-traversal/config/rdf-join/actors-inner-adaptive.json
@@ -8,7 +8,6 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-multi-empty/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-multi-smallest/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/^4.0.0/components/context.jsonld",
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-hash/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-symmetrichash/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-nestedloop/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-none/^4.0.0/components/context.jsonld",
@@ -29,7 +28,6 @@
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-smallest" }
       ]
     },
-
     {
       "@id": "urn:comunica:default:rdf-join/actors#inner-none",
       "@type": "ActorRdfJoinNone",
@@ -54,8 +52,6 @@
       "beforeActors": [
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-smallest" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-bind" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-nested-loop" }
       ]
@@ -69,25 +65,9 @@
       "mediatorMergeBindingsContext": { "@id": "urn:comunica:default:merge-bindings-context/mediators#main" },
       "beforeActors": [
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-smallest" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-nested-loop" }
       ]
-    },
-    {
-      "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def",
-      "@type": "ActorRdfJoinHash",
-      "mediatorJoinSelectivity": { "@id": "urn:comunica:default:rdf-join-selectivity/mediators#main" },
-      "mediatorHashBindings": { "@id": "urn:comunica:default:hash-bindings/mediators#main" },
-      "canHandleUndefs": false
-    },
-    {
-      "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef",
-      "@type": "ActorRdfJoinHash",
-      "mediatorJoinSelectivity": { "@id": "urn:comunica:default:rdf-join-selectivity/mediators#main" },
-      "mediatorHashBindings": { "@id": "urn:comunica:default:hash-bindings/mediators#main" },
-      "canHandleUndefs": true
     },
     {
       "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash",
@@ -115,8 +95,6 @@
       "mediatorJoin": { "@id": "urn:comunica:default:rdf-join/mediators#main" },
       "beforeActors": [
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-smallest" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-nested-loop" }
       ]

--- a/engines/config-query-sparql-link-traversal/config/rdf-join/actors-inner.json
+++ b/engines/config-query-sparql-link-traversal/config/rdf-join/actors-inner.json
@@ -6,7 +6,6 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-multi-bind-source/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-multi-smallest/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/^4.0.0/components/context.jsonld",
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-hash/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-symmetrichash/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-nestedloop/^4.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-join-inner-none/^4.0.0/components/context.jsonld",
@@ -34,8 +33,6 @@
       "beforeActors": [
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-smallest" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-bind" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-nested-loop" }
       ]
@@ -50,25 +47,9 @@
       "mediatorMergeBindingsContext": { "@id": "urn:comunica:default:merge-bindings-context/mediators#main" },
       "beforeActors": [
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-smallest" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-nested-loop" }
       ]
-    },
-    {
-      "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def",
-      "@type": "ActorRdfJoinHash",
-      "mediatorJoinSelectivity": { "@id": "urn:comunica:default:rdf-join-selectivity/mediators#main" },
-      "mediatorHashBindings": { "@id": "urn:comunica:default:hash-bindings/mediators#main" },
-      "canHandleUndefs": false
-    },
-    {
-      "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef",
-      "@type": "ActorRdfJoinHash",
-      "mediatorJoinSelectivity": { "@id": "urn:comunica:default:rdf-join-selectivity/mediators#main" },
-      "mediatorHashBindings": { "@id": "urn:comunica:default:hash-bindings/mediators#main" },
-      "canHandleUndefs": true
     },
     {
       "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash",
@@ -96,8 +77,6 @@
       "mediatorJoin": { "@id": "urn:comunica:default:rdf-join/mediators#main" },
       "beforeActors": [
         { "@id": "urn:comunica:default:rdf-join/actors#inner-multi-smallest" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-def" },
-        { "@id": "urn:comunica:default:rdf-join/actors#inner-hash-undef" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-symmetric-hash" },
         { "@id": "urn:comunica:default:rdf-join/actors#inner-nested-loop" }
       ]

--- a/engines/query-sparql-link-traversal-solid/package.json
+++ b/engines/query-sparql-link-traversal-solid/package.json
@@ -243,7 +243,6 @@
     "@comunica/actor-query-source-identify-rdfjs": "^4.1.0",
     "@comunica/actor-query-source-identify-serialized": "^4.1.0",
     "@comunica/actor-rdf-join-entries-sort-traversal-zero-knowledge": "^0.6.0",
-    "@comunica/actor-rdf-join-inner-hash": "^4.1.0",
     "@comunica/actor-rdf-join-inner-multi-bind": "^4.1.0",
     "@comunica/actor-rdf-join-inner-multi-bind-source": "^4.1.0",
     "@comunica/actor-rdf-join-inner-multi-smallest": "^4.1.0",

--- a/engines/query-sparql-link-traversal/package.json
+++ b/engines/query-sparql-link-traversal/package.json
@@ -239,7 +239,6 @@
     "@comunica/actor-query-source-identify-rdfjs": "^4.1.0",
     "@comunica/actor-query-source-identify-serialized": "^4.1.0",
     "@comunica/actor-rdf-join-entries-sort-traversal-zero-knowledge": "^0.6.0",
-    "@comunica/actor-rdf-join-inner-hash": "^4.1.0",
     "@comunica/actor-rdf-join-inner-multi-bind": "^4.1.0",
     "@comunica/actor-rdf-join-inner-multi-bind-source": "^4.1.0",
     "@comunica/actor-rdf-join-inner-multi-smallest": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2997,7 +2997,7 @@
     "@comunica/bus-rdf-join-entries-sort" "^4.1.0"
     "@comunica/core" "^4.1.0"
 
-"@comunica/actor-rdf-join-inner-hash@^4.0.1", "@comunica/actor-rdf-join-inner-hash@^4.1.0":
+"@comunica/actor-rdf-join-inner-hash@^4.0.1":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-4.1.0.tgz#ae29528b79e3e00f363f24059fb84705fc0d116b"
   integrity sha512-1ciPXwJkXtHD74YD/uLfK8IQ9Ah327czg6wTPCJigoYuyywiOYd88c96RyHuYuJqPKTWvCHvNt6DyQ5V3zYeDQ==


### PR DESCRIPTION
The hash join is a blocking join operator; this will halt query execution until all URIs have been dereferenced. 