### PR TITLE
Add an empty link filter list by default

### DIFF
--- a/packages/actor-context-preprocess-set-defaults-link-traversal/lib/ActorContextPreprocessSetDefaultsLinkTraversal.ts
+++ b/packages/actor-context-preprocess-set-defaults-link-traversal/lib/ActorContextPreprocessSetDefaultsLinkTraversal.ts
@@ -1,6 +1,7 @@
 import type { IActorContextPreprocessOutput, IActorContextPreprocessArgs } from '@comunica/bus-context-preprocess';
 import { ActorContextPreprocess } from '@comunica/bus-context-preprocess';
 import { KeysQuerySourceIdentify } from '@comunica/context-entries';
+import { KeysRdfResolveHypermediaLinks } from '@comunica/context-entries-link-traversal';
 import type { IAction, IActorTest, TestResult } from '@comunica/core';
 import { passTestVoid } from '@comunica/core';
 
@@ -22,6 +23,11 @@ export class ActorContextPreprocessSetDefaultsLinkTraversal extends ActorContext
     // Set traverse flag to true if the flag is undefined.
     if (!context.has(KeysQuerySourceIdentify.traverse)) {
       context = context.set(KeysQuerySourceIdentify.traverse, true);
+    }
+
+    // Set an empty link queue filter if it is undefined.
+    if (!context.has(KeysRdfResolveHypermediaLinks.linkFilters)) {
+      context = context.set(KeysRdfResolveHypermediaLinks.linkFilters, []);
     }
 
     return { context };

--- a/packages/actor-context-preprocess-set-defaults-link-traversal/package.json
+++ b/packages/actor-context-preprocess-set-defaults-link-traversal/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@comunica/bus-context-preprocess": "^4.1.0",
     "@comunica/context-entries": "^4.1.0",
+    "@comunica/context-entries-link-traversal": "^0.6.0",
     "@comunica/core": "^4.1.0"
   }
 }

--- a/packages/actor-context-preprocess-set-defaults-link-traversal/test/ActorContextPreprocessSetDefaultsLinkTraversal-test.ts
+++ b/packages/actor-context-preprocess-set-defaults-link-traversal/test/ActorContextPreprocessSetDefaultsLinkTraversal-test.ts
@@ -1,4 +1,5 @@
 import { KeysQuerySourceIdentify } from '@comunica/context-entries';
+import { KeysRdfResolveHypermediaLinks } from '@comunica/context-entries-link-traversal';
 import { ActionContext, Bus } from '@comunica/core';
 import { ActorContextPreprocessSetDefaultsLinkTraversal } from '../lib/ActorContextPreprocessSetDefaultsLinkTraversal';
 import '@comunica/utils-jest';
@@ -25,13 +26,49 @@ describe('ActorContextPreprocessSetDefaultsLinkTraversal', () => {
       it('with empty context', async() => {
         const contextIn = new ActionContext();
         const { context: contextOut } = await actor.run({ context: contextIn });
-        expect(contextOut).toEqual(new ActionContext().set(KeysQuerySourceIdentify.traverse, true));
+
+        const expectedContext = new ActionContext()
+          .set(KeysQuerySourceIdentify.traverse, true)
+          .set(KeysRdfResolveHypermediaLinks.linkFilters, []);
+
+        expect(contextOut).toEqual(expectedContext);
       });
 
       it('with KeysQuerySourceIdentify.traverse false', async() => {
         const contextIn = new ActionContext().set(KeysQuerySourceIdentify.traverse, false);
         const { context: contextOut } = await actor.run({ context: contextIn });
-        expect(contextOut).toEqual(new ActionContext().set(KeysQuerySourceIdentify.traverse, false));
+
+        const expectedContext = new ActionContext()
+          .set(KeysQuerySourceIdentify.traverse, false)
+          .set(KeysRdfResolveHypermediaLinks.linkFilters, []);
+
+        expect(contextOut).toEqual(expectedContext);
+      });
+
+      it('with KeysRdfResolveHypermediaLinks.linkFilters defined', async() => {
+        const a_filter = () => true;
+        const contextIn = new ActionContext().set(KeysRdfResolveHypermediaLinks.linkFilters, [ a_filter ]);
+        const { context: contextOut } = await actor.run({ context: contextIn });
+
+        const expectedContext = new ActionContext()
+          .set(KeysQuerySourceIdentify.traverse, true)
+          .set(KeysRdfResolveHypermediaLinks.linkFilters, [ a_filter ]);
+
+        expect(contextOut).toEqual(expectedContext);
+      });
+
+      it('with KeysRdfResolveHypermediaLinks.linkFilters and KeysQuerySourceIdentify.traverse defined', async() => {
+        const a_filter = () => true;
+        const contextIn = new ActionContext()
+          .set(KeysRdfResolveHypermediaLinks.linkFilters, [ a_filter ])
+          .set(KeysQuerySourceIdentify.traverse, false);
+        const { context: contextOut } = await actor.run({ context: contextIn });
+
+        const expectedContext = new ActionContext()
+          .set(KeysQuerySourceIdentify.traverse, false)
+          .set(KeysRdfResolveHypermediaLinks.linkFilters, [ a_filter ]);
+
+        expect(contextOut).toEqual(expectedContext);
       });
     });
   });


### PR DESCRIPTION
The new link filter implementation assumes that the context includes a list of filters, which is passed by reference. With the current setup, users must manually include at least an empty list of filters in the context. If they omit it, the link queue filter will not function correctly. Since including an empty array in the context is inexpensive, I propose that we initialize it by default to avoid this issue.
