### PR TITLE
Fix tab indentation in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
 bug 🐛:
     - '- :bug: Bug'
 feature ➕:
-	- '- :heavy_plus_sign: Feature request'
+    - '- :heavy_plus_sign: Feature request'
 performance 🐌:
-	- '- :snail: Performance issue'
+    - '- :snail: Performance issue'
 question ❓:
-	- '- :question: Question'
+    - '- :question: Question'


### PR DESCRIPTION
## Summary
- The "Label new issues" workflow (`.github/workflows/new-issue-label.yml`) was failing on every new/edited issue with `YAMLException: tab characters must not be used in indentation` when the `github/issue-labeler` action parsed `.github/labeler.yml`.
- Three of the four label rules used a literal tab character for the list-item indentation instead of spaces, which YAML disallows.
- Replaced the tab characters with spaces (matching the indentation style already used by the first rule), and confirmed the file now parses correctly as YAML.

Failing run: https://github.com/comunica/comunica-feature-link-traversal/actions/runs/28115968602

---
_Generated by [Claude Code](https://claude.ai/code/session_018FroxiFcBRhRnnxT9orfzM)_