### PR TITLE
Fix Web clients CI build failing on TypeScript type-stripping

### DIFF
--- a/web-clients/build-web-clients.sh
+++ b/web-clients/build-web-clients.sh
@@ -31,6 +31,7 @@ for config in ../config-query-sparql-link-traversal/config/*.json; do
     -d $cwd/web-clients/builds/$id \
     -s $cwd/web-clients/settings.custom.json \
     -q $cwd/web-clients/queries \
+    -w $cwd/web-clients/webpack.config.js \
     -b https://comunica.github.io/comunica-feature-link-traversal-web-clients/builds/$id/
 
   rm $cwd/web-clients/settings.custom.json

--- a/web-clients/webpack.config.js
+++ b/web-clients/webpack.config.js
@@ -1,0 +1,17 @@
+// Webpack >= 5.108 auto-enables its built-in TypeScript type-stripping support
+// (experiments.typescript = 'auto') whenever Node.js provides `module.stripTypeScriptTypes`
+// and no loader is registered for `.ts` files. This causes `.ts` extensions to outrank `.js`
+// during module resolution, so imports that used to resolve to the compiled `packages/*/lib/*.js`
+// output now resolve directly to the `packages/*/lib/*.ts` sources instead. Those sources rely on
+// TypeScript syntax (e.g. constructor parameter properties, angle-bracket type assertions) that
+// the strip-only mode does not support, which breaks the build.
+//
+// We don't compile against those `.ts` sources here (they're built to `.js` beforehand), so this
+// experiment is explicitly disabled to keep resolving to the compiled output as before.
+const baseConfig = require('@comunica/web-client-generator/webpack.config.js');
+
+for (const entry of baseConfig) {
+  entry.experiments = { ...entry.experiments, typescript: false };
+}
+
+module.exports = baseConfig;


### PR DESCRIPTION
## Summary

The `Web clients` CI job was failing with 8 webpack build errors like:

```
SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: The angle-bracket syntax for type assertions,
`<T>expr`, is not supported in type strip mode. Instead, use the 'as' syntax: `expr as T`.
```

and

```
SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported
in strip-only mode
```

### Root cause

Webpack >=5.108 auto-enables its built-in TypeScript type-stripping support (`experiments.typescript = 'auto'`) whenever Node.js provides `module.stripTypeScriptTypes` (Node ≥22.6, which the CI runner has) **and** no loader is registered for `.ts` files — which is the case in `@comunica/web-client-generator`'s webpack config.

When this experiment is enabled, webpack also reorders its default resolve extensions to `[".ts", ".js", ...]`, so `.ts` now outranks `.js` during module resolution. This meant package imports (e.g. `require('./SimpleSclParser')`) started resolving to the raw `packages/*/lib/*.ts` sources instead of the already-compiled `packages/*/lib/*.js` output. Those `.ts` sources use TypeScript syntax (constructor parameter properties, angle-bracket type assertions) that the strip-only mode doesn't support, breaking the build.

This is a pure dependency-version regression: nothing in this repo's source changed, `webpack` (a transitive dependency of `@comunica/web-client-generator`, pinned with `^5.69.0`) was bumped to a version that ships this new default behavior.

### Fix

`web-client-generator`'s CLI accepts a `-w` flag to override its webpack config. This PR adds `web-clients/webpack.config.js`, which requires the base config and explicitly disables `experiments.typescript` for both entries, restoring the previous behavior of resolving to the compiled `.js` output. `build-web-clients.sh` is updated to pass this override.

This avoids rewriting the flagged TypeScript syntax across 8+ actor packages, which would also conflict with this repo's ESLint rule mandating angle-bracket type assertions (`ts/consistent-type-assertions`).

### Verification

Since dependencies aren't committed to this branch, I manually installed and ran the actual `generate` webpack build (used by `build-web-clients.sh`) for both `config-default` and `config-solid-shapetrees` (which pulls in the other affected package) — both configs now build with 0 errors (only pre-existing bundle-size warnings), where they previously failed with the errors seen in CI.

## Test plan

- [x] `yarn install` (root + `web-clients/`)
- [x] `yarn run build` (`tsc` + `componentsjs-generator`) passes
- [x] `yarn test:unit` — 373 tests pass
- [x] `yarn run lint` passes (via pre-commit hook)
- [x] Manually ran the web client `generate` build for `config-default` and `config-solid-shapetrees` with the new `-w web-clients/webpack.config.js` override — both complete with 0 errors
- [x] CI will confirm the full `Web clients` job across all configs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi5bCfP5seGZRGKex95oLi)_